### PR TITLE
STALE-BRANCH-BACKUP - Update convict to version 6.0.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -88,7 +88,7 @@
         "client-oauth2": "^4.2.5",
         "compression": "^1.7.4",
         "connect-history-api-fallback": "^1.6.0",
-        "convict": "^5.0.0",
+        "convict": "^6.0.0",
         "csrf": "^3.1.0",
         "dotenv": "^8.0.0",
         "express": "^4.16.4",


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 