### PR TITLE
STALE-BRANCH-BACKUP - Update tslint to version 6.1.2

### DIFF
--- a/packages/editor-ui/package.json
+++ b/packages/editor-ui/package.json
@@ -72,7 +72,7 @@
     "sass-loader": "^8.0.0",
     "string-template-parser": "^1.2.6",
     "ts-jest": "^24.0.2",
-    "tslint": "^5.17.0",
+    "tslint": "^6.1.2",
     "typescript": "~3.7.4",
     "vue": "^2.6.9",
     "vue-cli-plugin-webpack-bundle-analyzer": "^2.0.0",


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 