### PR TITLE
STALE-BRANCH-BACKUP - :zap: Remove unnecessary parameter includeCredentialsOnBody

### DIFF
--- a/packages/core/src/NodeExecuteFunctions.ts
+++ b/packages/core/src/NodeExecuteFunctions.ts
@@ -171,8 +171,7 @@ export function requestOAuth2(this: IAllExecuteFunctions, credentialsType: strin
 				// Token is probably not valid anymore. So try refresh it.
 
 				const tokenRefreshOptions: IDataObject = {};
-
-				if (oAuth2Options?.includeCredentialsOnRefreshOnBody) {
+				if (credentials.authentication === 'body') {
 					const body: IDataObject = {
 						client_id: credentials.clientId as string,
 						client_secret: credentials.clientSecret as string,

--- a/packages/nodes-base/nodes/Box/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Box/GenericFunctions.ts
@@ -33,12 +33,8 @@ export async function boxApiRequest(this: IExecuteFunctions | IExecuteSingleFunc
 			delete options.body;
 		}
 
-		const oAuth2Options: IOAuth2Options = {
-			includeCredentialsOnRefreshOnBody: true,
-		};
-
 		//@ts-ignore
-		return await this.helpers.requestOAuth2.call(this, 'boxOAuth2Api', options, oAuth2Options);
+		return await this.helpers.requestOAuth2.call(this, 'boxOAuth2Api', options);
 
 	} catch (error) {
 

--- a/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Hubspot/GenericFunctions.ts
@@ -44,7 +44,7 @@ export async function hubspotApiRequest(this: IHookFunctions | IExecuteFunctions
 			return await this.helpers.request!(options);
 		} else {
 			// @ts-ignore
-			return await this.helpers.requestOAuth2!.call(this, 'hubspotOAuth2Api', options, { tokenType: 'Bearer', includeCredentialsOnRefreshOnBody: true });
+			return await this.helpers.requestOAuth2!.call(this, 'hubspotOAuth2Api', options, { tokenType: 'Bearer' });
 		}
 	} catch (error) {
 		let errorMessages;

--- a/packages/nodes-base/nodes/Mautic/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Mautic/GenericFunctions.ts
@@ -63,7 +63,7 @@ export async function mauticApiRequest(this: IHookFunctions | IExecuteFunctions 
 
 			options.uri = `${credentials.url}${options.uri}`;
 			//@ts-ignore
-			returnData = await this.helpers.requestOAuth2.call(this, 'mauticOAuth2Api', options, { includeCredentialsOnRefreshOnBody: true });
+			returnData = await this.helpers.requestOAuth2.call(this, 'mauticOAuth2Api', options);
 		}
 
 		if (returnData.errors) {

--- a/packages/nodes-base/nodes/Strava/GenericFunctions.ts
+++ b/packages/nodes-base/nodes/Strava/GenericFunctions.ts
@@ -45,7 +45,7 @@ export async function stravaApiRequest(this: IExecuteFunctions | IExecuteSingleF
 
 		} else {
 			//@ts-ignore
-			return await this.helpers.requestOAuth2.call(this, 'stravaOAuth2Api', options, { includeCredentialsOnRefreshOnBody: true });
+			return await this.helpers.requestOAuth2.call(this, 'stravaOAuth2Api', options);
 		}
 	} catch (error) {
 

--- a/packages/workflow/src/Interfaces.ts
+++ b/packages/workflow/src/Interfaces.ts
@@ -14,7 +14,6 @@ export interface IBinaryData {
 }
 
 export interface IOAuth2Options {
-	includeCredentialsOnRefreshOnBody?: boolean;
 	property?: string;
 	tokenType?: string;
 	keepBearer?: boolean;


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 