### PR TITLE
STALE-BRANCH-BACKUP - :bookmark: Release n8n@0.90.0

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -104,7 +104,7 @@
         "mysql2": "~2.1.0",
         "n8n-core": "~0.48.0",
         "n8n-editor-ui": "~0.60.0",
-        "n8n-nodes-base": "~0.84.1",
+        "n8n-nodes-base": "~0.85.0",
         "n8n-workflow": "~0.42.0",
         "oauth-1.0a": "^2.2.6",
         "open": "^7.0.0",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
     "name": "n8n",
-    "version": "0.89.2",
+    "version": "0.90.0",
     "description": "n8n Workflow Automation Tool",
     "license": "SEE LICENSE IN LICENSE.md",
     "homepage": "https://n8n.io",


### PR DESCRIPTION
This branch has been considered as a stale one. More than 3 months has passed from the last activity. This PR serves the backup purposes for easier restoration. 